### PR TITLE
add key/value store support for sql tables

### DIFF
--- a/lib/PicoDb/Database.php
+++ b/lib/PicoDb/Database.php
@@ -312,6 +312,19 @@ class Database
     }
 
     /**
+     * Get a hashtable instance
+     *
+     * @access public
+     * @return Picodb\Hashtable
+     */
+    public function hashtable($table_name)
+    {
+        require_once __DIR__.'/Table.php';
+        require_once __DIR__.'/Hashtable.php';
+        return new Hashtable($this, $table_name);
+    }
+
+    /**
      * Get a schema instance
      *
      * @access public

--- a/lib/PicoDb/Hashtable.php
+++ b/lib/PicoDb/Hashtable.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace PicoDb;
+
+use PDO;
+
+class Hashtable extends Table
+{
+    private $column_key = 'key';
+    private $column_value = 'value';
+
+    /**
+     * Set the key column
+     *
+     * @access public
+     * @param  string $column
+     * @return \PicoDb\Table
+     */
+    public function columnKey($column)
+    {
+        $this->column_key = $column;
+        return $this;
+    }
+
+    /**
+     * Set the value column
+     *
+     * @access public
+     * @param  string $column
+     * @return \PicoDb\Table
+     */
+    public function columnValue($column)
+    {
+        $this->column_value = $column;
+        return $this;
+    }
+
+    /**
+     * Insert or update
+     *
+     * @access public
+     * @param  array    $data
+     * @return boolean
+     */
+    public function put(array $data)
+    {
+        switch ($this->db->getConnection()->getAttribute(PDO::ATTR_DRIVER_NAME)) {
+            case 'mysql':
+                $sql = sprintf(
+                    'REPLACE INTO %s (%s) VALUES %s',
+                    $this->db->escapeIdentifier($this->table_name),
+                    "$this->column_key, $this->column_value",
+                    implode(', ', array_fill(0, count($data), '(?, ?)'))
+                );
+
+                foreach ($data as $key => $value) {
+                    $this->values[] = $key;
+                    $this->values[] = $value;
+                }
+
+                $this->db->execute($sql, $this->values);
+                break;
+            case 'sqlite': // multi insert (see mysql) requires sqlite library > 3.7.11 (bundled with PHP 5.5.11+)
+                // all or nothing
+                $this->db->startTransaction();
+
+                foreach($data as $key => $value) {
+                    $sql = sprintf(
+                        'INSERT OR REPLACE INTO %s (%s) VALUES (?, ?)',
+                        $this->db->escapeIdentifier($this->table_name),
+                        $this->db->escapeIdentifier($this->column_key).', '.$this->db->escapeIdentifier($this->column_value)
+                    );
+
+                    $this->db->execute($sql, array($key, $value));
+                }
+
+                break;
+            default: // no upsert available, need to make a select/update/insert limbo
+                // all or nothing
+                $this->db->startTransaction();
+
+                foreach($data as $key => $value) {
+                    // check if the key exists
+                    $this->eq($this->column_key, $key);
+
+                    if ($this->count() === 1) {
+                        // update the record
+                        $this->update(array($this->column_key => $key, $this->column_value => $value));
+                    }
+                    else {
+                        // insert the record
+                        $this->insert(array($this->column_key => $key, $this->column_value => $value));
+                    }
+                }
+        }
+
+        $this->db->closeTransaction();
+
+        return true;
+    }
+
+    /**
+     * Hashmap result [ [column1 => column2], [], ...]
+     *
+     * @access public
+     * @return array
+     */
+    public function get()
+    {
+        $hashmap = array();
+
+        // setup where condition
+        if (func_num_args() > 0) {
+            $this->in($this->column_key, func_get_args());
+        }
+
+        // setup to select columns in case that there are more than two
+        $this->columns($this->column_key,$this->column_value);
+
+        $rq = $this->db->execute($this->buildSelectQuery(), $this->values);
+        $rows = $rq->fetchAll(PDO::FETCH_NUM);
+
+        foreach ($rows as $row) {
+            $hashmap[$row[0]] = $row[1];
+        }
+
+        return $hashmap;
+    }
+}

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -9,7 +9,10 @@ class Table
     const SORT_ASC = 'ASC';
     const SORT_DESC = 'DESC';
 
-    private $table_name = '';
+    protected $db;
+    protected $table_name = '';
+    protected $values = array();
+
     private $sql_limit = '';
     private $sql_offset = '';
     private $sql_order = '';
@@ -18,11 +21,9 @@ class Table
     private $or_conditions = array();
     private $is_or_condition = false;
     private $columns = array();
-    private $values = array();
     private $distinct = false;
     private $group_by = array();
     private $filter_callback = null;
-    private $db;
 
     /**
      * Constructor
@@ -128,30 +129,6 @@ class Table
 
         $result = $this->db->execute($sql, $this->values);
         return $result->rowCount() > 0;
-    }
-
-    /**
-     * Hashmap result [ [column1 => column2], [], ...]
-     *
-     * @access public
-     * @param  string    $key      Column 1
-     * @param  string    $value    Column 2
-     * @return array
-     */
-    public function hashmap($key, $value)
-    {
-        $listing = array();
-
-        $this->columns($key, $value);
-        $rq = $this->db->execute($this->buildSelectQuery(), $this->values);
-
-        $rows = $rq->fetchAll(PDO::FETCH_NUM);
-
-        foreach ($rows as $row) {
-            $listing[$row[0]] = $row[1];
-        }
-
-        return $listing;
     }
 
     /**


### PR DESCRIPTION
Reference implementation can be be found in my miniflux fork: https://github.com/mkresin/miniflux/commit/7ea0495ec52a31880cb2bcc842e581225fb29e98

<h1>Simple tests</h1>

```php
$db = new Database(['driver' => 'sqlite', 'filename' => ':memory:']);

$db->execute(
    'CREATE TABLE toto (
        column1 TEXT NOT NULL UNIQUE,
        column2 TEXT default NULL
    )'
);

$db->execute('INSERT INTO toto (column1, column2) VALUES ("option1", "value1")');
$db->execute('INSERT INTO toto (column1, column2) VALUES ("option2", "value2")');
$db->execute('INSERT INTO toto (column1, column2) VALUES ("option3", "value3")');

$hasharray = array(
        'option1' => 'hey',
        'option4' => 'ho'
);

if (!$db->hashtable('toto')->columnKey('column1')->columnValue('column2')->put($hasharray)) {
    echo "hasharray could not be stored";
}
```

<h2>Get values of specific keys</h2>

```php
$result = $db->hashtable('toto')->columnKey('column1')->columnValue('column2')->get('option2','option4');
print_r($result);
```
<pre>
Array
(
    [option2] => value2
    [option4] => ho
)
</pre>

<h2>Get all key/values</h2>

```php
$result = $db->hashtable('toto')->columnKey('column1')->columnValue('column2')->get();
print_r($result);
```
<pre>
Array
(
    [option2] => value2
    [option3] => value3
    [option1] => hey
    [option4] => ho
)
</pre>

<h2>dump altered example table using classic table class</h2>
```php
$result = $db->table('toto')->findAll();
print_r($result);
```
<pre>
Array
(
    [0] => Array
        (
            [column1] => option2
            [column2] => value2
        )

    [1] => Array
        (
            [column1] => option3
            [column2] => value3
        )

    [2] => Array
        (
            [column1] => option1
            [column2] => hey
        )

    [3] => Array
        (
            [column1] => option4
            [column2] => ho
        )

)
</pre>