### PR TITLE
Table::count() taking joins into consideration

### DIFF
--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -267,7 +267,7 @@ class Table
     public function count()
     {
         $sql = sprintf(
-            'SELECT COUNT(*) FROM %s'.$this->conditions().$this->sql_order.$this->sql_limit.$this->sql_offset,
+            'SELECT COUNT(*) FROM %s '.implode(' ', $this->joins).$this->conditions().$this->sql_order.$this->sql_limit.$this->sql_offset,
             $this->db->escapeIdentifier($this->table_name)
         );
 


### PR DESCRIPTION
Right now, Table::count() doesn't include joins, which results in wrong counting as well as errors when applying filters across multiple tables.