### PR TITLE
Some phpdocs and a typo

### DIFF
--- a/lib/PicoDb/Database.php
+++ b/lib/PicoDb/Database.php
@@ -161,7 +161,7 @@ class Database
      * Get the PDO connection
      *
      * @access public
-     * @return PDO
+     * @return \PDO
      */
     public function getConnection()
     {
@@ -247,7 +247,7 @@ class Database
      * @access public
      * @param  string    $sql      SQL query
      * @param  array     $values   Values
-     * @return PDOStatement|false
+     * @return \PDOStatement|false
      */
     public function execute($sql, array $values = array())
     {
@@ -304,7 +304,8 @@ class Database
      *
      * @access private
      * @param  PDOException $e
-     * @return boolean
+     * @return bool
+     * @throws SQLException
      */
     private function handleSqlError(PDOException $e)
     {
@@ -358,6 +359,7 @@ class Database
      * Get a table instance
      *
      * @access public
+     * @param  string $table_name
      * @return Table
      */
     public function table($table_name)
@@ -369,6 +371,7 @@ class Database
      * Get a hashtable instance
      *
      * @access public
+     * @param  string    $table_name
      * @return Hashtable
      */
     public function hashtable($table_name)

--- a/lib/PicoDb/Driver/Base.php
+++ b/lib/PicoDb/Driver/Base.php
@@ -157,15 +157,15 @@ abstract class Base
      * @param  string  $table
      * @param  string  $keyColumn
      * @param  string  $valueColumn
-     * @param  array   $dictionnary
+     * @param  array   $dictionary
      * @return bool    False on failure
      */
-    public function upsert($table, $keyColumn, $valueColumn, array $dictionnary)
+    public function upsert($table, $keyColumn, $valueColumn, array $dictionary)
     {
         try {
             $this->pdo->beginTransaction();
 
-            foreach ($dictionnary as $key => $value) {
+            foreach ($dictionary as $key => $value) {
 
                 $rq = $this->pdo->prepare('SELECT 1 FROM '.$this->escape($table).' WHERE '.$this->escape($keyColumn).'=?');
                 $rq->execute(array($key));

--- a/lib/PicoDb/Driver/Base.php
+++ b/lib/PicoDb/Driver/Base.php
@@ -158,6 +158,7 @@ abstract class Base
      * @param  string  $keyColumn
      * @param  string  $valueColumn
      * @param  array   $dictionnary
+     * @return bool    False on failure
      */
     public function upsert($table, $keyColumn, $valueColumn, array $dictionnary)
     {

--- a/lib/PicoDb/Driver/Mysql.php
+++ b/lib/PicoDb/Driver/Mysql.php
@@ -177,6 +177,7 @@ class Mysql extends Base
      * @param  string  $keyColumn
      * @param  string  $valueColumn
      * @param  array   $dictionnary
+     * @return bool    False on failure
      */
     public function upsert($table, $keyColumn, $valueColumn, array $dictionnary)
     {

--- a/lib/PicoDb/Driver/Mysql.php
+++ b/lib/PicoDb/Driver/Mysql.php
@@ -176,10 +176,10 @@ class Mysql extends Base
      * @param  string  $table
      * @param  string  $keyColumn
      * @param  string  $valueColumn
-     * @param  array   $dictionnary
+     * @param  array   $dictionary
      * @return bool    False on failure
      */
-    public function upsert($table, $keyColumn, $valueColumn, array $dictionnary)
+    public function upsert($table, $keyColumn, $valueColumn, array $dictionary)
     {
         try {
 
@@ -188,12 +188,12 @@ class Mysql extends Base
                 $this->escape($table),
                 $this->escape($keyColumn),
                 $this->escape($valueColumn),
-                implode(', ', array_fill(0, count($dictionnary), '(?, ?)'))
+                implode(', ', array_fill(0, count($dictionary), '(?, ?)'))
             );
 
             $values = array();
 
-            foreach ($dictionnary as $key => $value) {
+            foreach ($dictionary as $key => $value) {
                 $values[] = $key;
                 $values[] = $value;
             }

--- a/lib/PicoDb/Driver/Sqlite.php
+++ b/lib/PicoDb/Driver/Sqlite.php
@@ -136,6 +136,7 @@ class Sqlite extends Base
      * @param  string  $keyColumn
      * @param  string  $valueColumn
      * @param  array   $dictionnary
+     * @return bool    False on failure
      */
     public function upsert($table, $keyColumn, $valueColumn, array $dictionnary)
     {

--- a/lib/PicoDb/Driver/Sqlite.php
+++ b/lib/PicoDb/Driver/Sqlite.php
@@ -135,15 +135,15 @@ class Sqlite extends Base
      * @param  string  $table
      * @param  string  $keyColumn
      * @param  string  $valueColumn
-     * @param  array   $dictionnary
+     * @param  array   $dictionary
      * @return bool    False on failure
      */
-    public function upsert($table, $keyColumn, $valueColumn, array $dictionnary)
+    public function upsert($table, $keyColumn, $valueColumn, array $dictionary)
     {
         try {
             $this->pdo->beginTransaction();
 
-            foreach ($dictionnary as $key => $value) {
+            foreach ($dictionary as $key => $value) {
 
                 $sql = sprintf(
                     'INSERT OR REPLACE INTO %s (%s, %s) VALUES (?, ?)',

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -528,6 +528,7 @@ class Table
      * Custom select
      *
      * @access public
+     * @param  string $select
      * @return Table
      */
     public function select($select)


### PR DESCRIPTION
Hey, just some minor edits after reading your code.
- use `\PDO` as a fully qualified namespace to avoid any confusion.
- add missing params
- fix typo "dictionnary"

Kudos on your style. Lots of functionality that is easy to read without over-engineering :+1: 