### PR TITLE
Improvements for UTF 8 connections when values in database has special chars

### DIFF
--- a/lib/PicoDb/Driver/Mysql.php
+++ b/lib/PicoDb/Driver/Mysql.php
@@ -53,6 +53,18 @@ class Mysql extends Base
             $this->schemaTable = $settings['schema_table'];
         }
 
+        $this->fixSetNamesUtf8();
+    }
+
+    /**
+     * Fix connection with tables using UTF8 and table values contains especial chars, as á, ç, ñ, ã...
+     */
+    protected function fixSetNamesUtf8() {
+        if (strtolower($this->getCharset()) === 'utf8') {
+            $this->pdo->exec('SET NAMES "utf8"');
+        }
+    }
+
     /**
      * Get charset from settings
      */

--- a/lib/PicoDb/Driver/Mysql.php
+++ b/lib/PicoDb/Driver/Mysql.php
@@ -52,6 +52,12 @@ class Mysql extends Base
         if (isset($settings['schema_table'])) {
             $this->schemaTable = $settings['schema_table'];
         }
+
+    /**
+     * Get charset from settings
+     */
+    protected function getCharset() {
+        return empty($settings['charset']) ? 'utf8' : $settings['charset'];
     }
 
     /**
@@ -63,8 +69,7 @@ class Mysql extends Base
      */
     protected function buildDsn(array $settings)
     {
-        $charset = empty($settings['charset']) ? 'utf8' : $settings['charset'];
-        $dsn = 'mysql:host='.$settings['hostname'].';dbname='.$settings['database'].';charset='.$charset;
+        $dsn = 'mysql:host='.$settings['hostname'].';dbname='.$settings['database'].';charset='.$this->getCharset();
 
         if (! empty($settings['port'])) {
             $dsn .= ';port='.$settings['port'];


### PR DESCRIPTION
Even with a basis already in UTF8 and COLLATE UTF8, the values response by class with "?" char.
WIth this changes, the chars as "ñ" or "ã" are show correctly.