### PR TITLE
Only the database in mandatory in postgres' dsn

### DIFF
--- a/lib/PicoDb/Driver/Postgres.php
+++ b/lib/PicoDb/Driver/Postgres.php
@@ -20,9 +20,6 @@ class Postgres extends Base
      * @var array
      */
     protected $requiredAttributes = array(
-        'hostname',
-        'username',
-        'password',
         'database',
     );
 
@@ -42,13 +39,25 @@ class Postgres extends Base
      */
     public function createConnection(array $settings)
     {
-        $dsn = 'pgsql:host='.$settings['hostname'].';dbname='.$settings['database'];
+        $dsn = 'pgsql:dbname='.$settings['database'];
+
+        if (! empty($settings['username'])) {
+            $dsn .= ';user='.$settings['username'];
+        }
+
+        if (! empty($settings['password'])) {
+            $dsn .= ';password='.$settings['password'];
+        }
+
+        if (! empty($settings['hostname'])) {
+            $dsn .= ';host='.$settings['hostname'];
+        }
 
         if (! empty($settings['port'])) {
             $dsn .= ';port='.$settings['port'];
         }
 
-        $this->pdo = new PDO($dsn, $settings['username'], $settings['password']);
+        $this->pdo = new PDO($dsn);
 
         if (isset($settings['schema_table'])) {
             $this->schemaTable = $settings['schema_table'];


### PR DESCRIPTION
My setups generally use local account to connect to the db so username and passwords aren't needed, and they connect through the unix socket, so hostname isn't needed either.

Superseeds #20 