### PR TITLE
Add PDO::ATTR_CASE option

### DIFF
--- a/lib/PicoDb/Driver/Mysql.php
+++ b/lib/PicoDb/Driver/Mysql.php
@@ -110,6 +110,10 @@ class Mysql extends Base
             $options[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = $settings['verify_server_cert'];
         }
 
+        if (! empty($settings['case'])) {
+            $options[PDO::ATTR_CASE] = $settings['case'];
+        }
+
         return $options;
     }
 


### PR DESCRIPTION
 PDO::ATTR_CASE: Force column names to a specific case.

    PDO::CASE_LOWER: Force column names to lower case.

    PDO::CASE_NATURAL: Leave column names as returned by the database driver.

    PDO::CASE_UPPER: Force column names to upper case.

